### PR TITLE
Replace 'foreign' with 'crossorigin' in the polyfill and tests.

### DIFF
--- a/tests/resources/accepting-worker.js
+++ b/tests/resources/accepting-worker.js
@@ -1,5 +1,5 @@
 importScripts('../../polyfill/service-polyfill.js');
 
-self.addEventListener('foreignconnect', function(event) {
+self.addEventListener('crossoriginconnect', function(event) {
   event.acceptConnection(true);
 });

--- a/tests/resources/connect.js
+++ b/tests/resources/connect.js
@@ -19,7 +19,7 @@ promise_test(function(test) {
         }),
       'AbortError',
       'navigator.connect should fail with an AbortError');
-  }, 'Connection fails if service worker doesn\'t handle onforeignconnect.', properties);
+  }, 'Connection fails if service worker doesn\'t handle oncrossoriginconnect.', properties);
 */
 
 promise_test(function(test) {

--- a/tests/resources/echo-worker.js
+++ b/tests/resources/echo-worker.js
@@ -1,10 +1,10 @@
 importScripts('../../polyfill/service-polyfill.js');
 
-self.addEventListener('foreignconnect', function(event) {
+self.addEventListener('crossoriginconnect', function(event) {
   event.acceptConnection(true);
 });
 
 
-self.addEventListener('foreignmessage', function(event) {
+self.addEventListener('crossoriginmessage', function(event) {
   event.source.postMessage(event.data, event.ports);
 });

--- a/tests/resources/rejecting-worker.js
+++ b/tests/resources/rejecting-worker.js
@@ -1,5 +1,5 @@
 importScripts('../../polyfill/service-polyfill.js');
 
-self.addEventListener('foreignconnect', function(event) {
+self.addEventListener('crossoriginconnect', function(event) {
   event.acceptConnection(false);
 });


### PR DESCRIPTION
This brings the event names up to speed with the current spec.
