### PR TITLE
Connect algorithm: fire connect event at navigator.services, not global.

### DIFF
--- a/index.html
+++ b/index.html
@@ -575,7 +575,8 @@ self.addEventListener('push', function(event) {
                     following substeps:
                     <ol>
                       <li>Fire an event named <code><a>connect</a></code> using
-                      <code><a>ServicePortConnectEvent</a></code> interface at <var>global</var>.
+                      <code><a>ServicePortConnectEvent</a></code> interface at
+                      <var>global</var><code>.navigator.services</code>.
                         <p class="issue">
                           Better define these next steps.
                         </p>


### PR DESCRIPTION
In a previous version of the spec, event handlers were installed on the
global object in the service worker. Since event handlers are now
registered on the ServicePortCollection object (navigator.services), the
event needs to be fired at that object instead.
